### PR TITLE
chore: build nonroot following Atlas example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,20 @@
 # Build the binary on the golang image
-FROM golang:1.24-alpine AS build
-WORKDIR /app
-COPY go.mod go.sum ./
-RUN go mod download
-COPY . .
-ENV CGO_ENABLED=0
-RUN go build -o service ./cmd/server/main.go
+FROM golang:1.25 AS build
+WORKDIR /go/src/app
 
-# Run the binary on distroless
-FROM gcr.io/distroless/base:latest
-WORKDIR /root
-COPY --from=build /app/service .
+# Dependencies
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# Build
+COPY . .
+RUN CGO_ENABLED=0 go build -ldflags="-extldflags=-static -s" -buildvcs=false -o /go/bin/service ./cmd/server/main.go
+
+# Run the binary on distroless non-root
+FROM gcr.io/distroless/static-debian12:nonroot
+WORKDIR /app
+COPY --from=build /go/bin/service /app/service
 EXPOSE 8080
-CMD ["./service"]
+
+ENTRYPOINT ["/app/service"]


### PR DESCRIPTION
Currently this image runs as root on production, which could potentially be a security issue.

This PR changes the CI to follow Atlas' example.
https://github.com/clinia/atlas/blob/main/Dockerfile

Builds a static binary and runs it on Debian distroless non-root.