### PR TITLE
chore: Update GitHub workflow

### DIFF
--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -58,7 +58,7 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: digests
           path: /tmp/digests/*
@@ -71,7 +71,7 @@ jobs:
       - build
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: digests
           path: /tmp/digests


### PR DESCRIPTION
The release CI is currently failing due to a deprecated step in the GitHub CI. This PR simply updates these steps.

See:
- [failing workflow](https://github.com/clinia/kratos-readonly-traits/actions/runs/21256358022/job/61171923404)
- [deprecation notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)